### PR TITLE
Add centralized app settings configuration utilities

### DIFF
--- a/Configuration/AppSetting/AppSetting.csproj
+++ b/Configuration/AppSetting/AppSetting.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Configuration/AppSetting/AppSettingConfiguration.cs
+++ b/Configuration/AppSetting/AppSettingConfiguration.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Configuration;
+
+public static class AppSettingConfiguration
+{
+    public static WebApplicationBuilder InjectAppConfiguration<T>(this WebApplicationBuilder builder)
+        where T : class
+    {
+        builder.Services.Configure<T>(builder.Configuration);
+
+        return builder;
+    }
+
+    public static IServiceCollection InjectHostOptions(this IServiceCollection services)
+    {
+        services.Configure<HostOptions>(options =>
+        {
+            options.BackgroundServiceExceptionBehavior =
+                BackgroundServiceExceptionBehavior.Ignore;
+        });
+
+        return services;
+    }
+    public static IServiceCollection SetMaxRequestBodySize(this IServiceCollection services, int maxRequestBodySizeInMb)
+    {
+        services.Configure<KestrelServerOptions>(opts =>
+        {
+            opts.Limits.MaxRequestBodySize = maxRequestBodySizeInMb * 1024 * 1024;
+        });
+        return services;
+    }
+
+    public static T RetrieveAppSetting<T>(this WebApplicationBuilder builder)
+        where T : class
+    {
+        return builder.Configuration.Get<T>() ?? throw new InvalidOperationException("AppSetting not found");
+    }
+
+}


### PR DESCRIPTION
Introduces reusable methods for injecting and retrieving strongly-typed app settings, configuring host options, and setting request body size limits.   Facilitates consistent and simplified setup for application configuration across projects.