### PR TITLE
Add automatic scoped service registration extension for DI

### DIFF
--- a/Configuration/DependencyInjection/DependencyInjection.cs
+++ b/Configuration/DependencyInjection/DependencyInjection.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using Common.Interface;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Configuration;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AutoAddScopedServiceByIScopedService(this IServiceCollection services)
+    {
+        services.Scan(scan =>
+        {
+            scan
+            .FromApplicationDependencies()
+            .AddClasses(classes => classes.AssignableTo<IScopedService>())
+            .AsImplementedInterfaces()
+            .WithScopedLifetime();
+        });
+
+        return services;
+    }
+}

--- a/Configuration/DependencyInjection/DependencyInjection.csproj
+++ b/Configuration/DependencyInjection/DependencyInjection.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\Common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Introduces an extension method to scan dependencies and auto-register implementations of a designated scoped service interface, streamlining DI configuration and reducing manual setup. Includes project setup with required dependencies.