### PR TITLE
Vault refresh system refactor with centralized token handling and Quartz-based self-rescheduling job

### DIFF
--- a/Api/Interface/Broker/IVaultHttpClientBrokerService.cs
+++ b/Api/Interface/Broker/IVaultHttpClientBrokerService.cs
@@ -6,6 +6,6 @@ namespace Api.Interface.Broker
     {
         ValueTask<PostVaultAuthResponseDto> PostLoginAsync(CancellationToken cancellationToken = default);
         ValueTask<GetVaultRootSecretResponseDto> GetPersonaRootDataAsync(CancellationToken cancellationToken = default);
-        ValueTask<PostVaultDatabaseCredentialResponseDto> PostPostgresCredentialAsync(string databaseEngineName, string databaseEngineRole, CancellationToken cancellationToken = default);
+        ValueTask<VaultResponseWrapperDto<PostVaultDatabaseCredentialResponseDto>> PostPostgresCredentialAsync(string databaseEngineName, string databaseEngineRole, CancellationToken cancellationToken = default);
     }
 }

--- a/Api/Job/RefreshVaultPostgresCredentialJob.cs
+++ b/Api/Job/RefreshVaultPostgresCredentialJob.cs
@@ -1,0 +1,44 @@
+using Api.Interface.Processing;
+using Api.Model.Common;
+using Quartz;
+using QuartzScheduler.Interface;
+
+namespace Api.Service.Job
+{
+    [DisallowConcurrentExecution]
+    public class RefreshVaultPostgresCredentialJob(
+        IApplicationSettingProcessingService iApplicationSettingProcessingService,
+        IQuartzSchedulerBrokerService iQuartzSchedulerBrokerService,
+        AppSettings appSettings,
+        ILogger<RefreshVaultPostgresCredentialJob> iLogger
+    ) : IJob
+    {
+        public async Task Execute(IJobExecutionContext context)
+        {
+            try
+            {
+                AppSettings updatedAppSettings = await iApplicationSettingProcessingService.ProcessRetrieveVaultPostgresCredentialAsync(appSettings);
+
+                iLogger.LogInformation("Postgres credential refreshed successfully");
+
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+                DateTimeOffset runAt = now + (updatedAppSettings.PostgresSettings.ExpireAt - now) * 0.8;
+
+                if (runAt <= DateTimeOffset.UtcNow)
+                {
+                    iLogger.LogWarning("Computed runAt {RunAt} is in the past. Skipping scheduling.", runAt);
+                    return;
+                }
+
+                await iQuartzSchedulerBrokerService.ScheduleJobAsync<RefreshVaultPostgresCredentialJob>(runAt);
+
+                iLogger.LogInformation("Scheduled RefreshVaultPostgresCredentialJob at {RunAt}", runAt);
+            }
+            catch (Exception ex)
+            {
+                iLogger.LogError(ex, "Failed to refresh Postgres credential");
+                throw;
+            }
+        }
+    }
+}

--- a/Api/Model/Common/AppSettings.cs
+++ b/Api/Model/Common/AppSettings.cs
@@ -15,6 +15,7 @@ namespace Api.Model.Common
         public string BaseUrl { get; set; } = string.Empty;
         public string Username { get; set; } = string.Empty;
         public string Password { get; set; } = string.Empty;
+        public string? Token { get; set; }
         public DateTimeOffset ExpireAt { get; set; } = DateTimeOffset.UtcNow;
     }
 }

--- a/Api/Model/Dto/Response/PostVaultDatabaseCredentialResponseDto.cs
+++ b/Api/Model/Dto/Response/PostVaultDatabaseCredentialResponseDto.cs
@@ -9,8 +9,5 @@ namespace Api.Model.Dto.Response
 
         [JsonPropertyName("password")]
         public string Password { get; set; } = default!;
-
-        [JsonPropertyName("lease_duration")]
-        public int LeaseDuration { get; set; }
     }
 }

--- a/Api/Model/Dto/Response/VaultResponseWrapperDto.cs
+++ b/Api/Model/Dto/Response/VaultResponseWrapperDto.cs
@@ -17,7 +17,7 @@ namespace Api.Model.Dto.Response
         public int LeaseDuration { get; init; }
 
         [JsonPropertyName("data")]
-        public T? Data { get; init; }
+        public required T Data { get; init; }
 
         [JsonPropertyName("wrap_info")]
         public object? WrapInfo { get; init; }

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -59,7 +59,8 @@ builder.Services.AddResponseCaching();
 
 builder.Services.SetMaxRequestBodySize(maxRequestBodySizeInMb: 5);
 
-builder.Services.AddHostedService<RefreshBackgroundService>();
+builder.Services.AddHostedService<RefreshVaultAppSettingBackgroundService>();
+builder.Services.AddHostedService<RefreshVaultPostgresCredentialBackgroundService>();
 
 WebApplication app = builder.Build();
 

--- a/Api/Service/Background/RefreshVaultAppSettingBackgroundService.cs
+++ b/Api/Service/Background/RefreshVaultAppSettingBackgroundService.cs
@@ -1,14 +1,13 @@
 using Api.Model.Common;
 using Api.Service.Job;
-using Common.Interface;
 using QuartzScheduler.Interface;
 
 namespace Api.Service.Background
 {
-    public class RefreshBackgroundService(
+    public class RefreshVaultAppSettingBackgroundService(
         IServiceProvider serviceProvider,
         AppSettings appSettings,
-        ILogger<RefreshBackgroundService> iLogger
+        ILogger<RefreshVaultAppSettingBackgroundService> iLogger
     ) : BackgroundService
     {
         protected override async Task ExecuteAsync(CancellationToken cancellationToken)

--- a/Api/Service/Background/RefreshVaultPostgresCredentialBackgroundService.cs
+++ b/Api/Service/Background/RefreshVaultPostgresCredentialBackgroundService.cs
@@ -1,0 +1,40 @@
+using Api.Model.Common;
+using Api.Service.Job;
+using QuartzScheduler.Interface;
+
+namespace Api.Service.Background
+{
+    public class RefreshVaultPostgresCredentialBackgroundService(
+        IServiceProvider serviceProvider,
+        AppSettings appSettings,
+        ILogger<RefreshVaultPostgresCredentialBackgroundService> iLogger
+    ) : BackgroundService
+    {
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            using IServiceScope scope = serviceProvider.CreateScope();
+
+            IQuartzSchedulerBrokerService schedulerBroker = scope.ServiceProvider.GetRequiredService<IQuartzSchedulerBrokerService>();
+
+            try
+            {
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+                DateTimeOffset runAt = now + (appSettings.PostgresSettings.ExpireAt - now) * 0.8;
+
+                if (runAt <= DateTimeOffset.UtcNow)
+                {
+                    iLogger.LogWarning("Computed runAt {RunAt} is in the past. Skipping scheduling.", runAt);
+                    return;
+                }
+
+                await schedulerBroker.ScheduleJobAsync<RefreshVaultPostgresCredentialJob>(runAt, cancellationToken);
+
+                iLogger.LogInformation("Scheduled RefreshVaultPostgresCredentialJob at {RunAt}", runAt);
+            }
+            catch (Exception ex)
+            {
+                iLogger.LogError(ex, "Failed to schedule Vault Postgres credential refresh job on startup");
+            }
+        }
+    }
+}

--- a/Api/Service/Broker/VaultHttpClientBrokerService/VaultHttpClientBrokerService.Auth.cs
+++ b/Api/Service/Broker/VaultHttpClientBrokerService/VaultHttpClientBrokerService.Auth.cs
@@ -18,9 +18,6 @@ namespace Api.Service.Broker.VaultHttpClientBrokerService
 
             PostVaultAuthResponseDto postVaultAuthResponseDto = (await response.Content.ReadFromJsonAsync<VaultResponseWrapperDto>(cancellationToken: cancellationToken))?.Auth ?? throw new JsonException("Invalid response from Vault");
 
-            httpClient.DefaultRequestHeaders.Remove("X-Vault-Token");
-            httpClient.DefaultRequestHeaders.Add("X-Vault-Token", postVaultAuthResponseDto.ClientToken);
-
             return postVaultAuthResponseDto;
         }
     }

--- a/Api/Service/Broker/VaultHttpClientBrokerService/VaultHttpClientBrokerService.PersonaPostgres.cs
+++ b/Api/Service/Broker/VaultHttpClientBrokerService/VaultHttpClientBrokerService.PersonaPostgres.cs
@@ -7,7 +7,7 @@ namespace Api.Service.Broker.VaultHttpClientBrokerService
 {
     public partial class VaultHttpClientBrokerService : IVaultHttpClientBrokerService, IScopedService
     {
-        public async ValueTask<PostVaultDatabaseCredentialResponseDto> PostPostgresCredentialAsync(string databaseEngineName, string databaseEngineRole, CancellationToken cancellationToken = default)
+        public async ValueTask<VaultResponseWrapperDto<PostVaultDatabaseCredentialResponseDto>> PostPostgresCredentialAsync(string databaseEngineName, string databaseEngineRole, CancellationToken cancellationToken = default)
         {
             string url = $"{appSettings.VaultHttpClient.BaseUrl}/v1/{databaseEngineName}/creds/{databaseEngineRole}";
 
@@ -21,7 +21,7 @@ namespace Api.Service.Broker.VaultHttpClientBrokerService
                 throw new HttpRequestException(
                     $"Vault request failed: {(int)response.StatusCode} {response.ReasonPhrase} " + $"{await response.Content.ReadAsStringAsync(cancellationToken)}");
 
-            return (await response.Content.ReadFromJsonAsync<VaultResponseWrapperDto<PostVaultDatabaseCredentialResponseDto>>(cancellationToken))?.Data ??
+            return (await response.Content.ReadFromJsonAsync<VaultResponseWrapperDto<PostVaultDatabaseCredentialResponseDto>>(cancellationToken)) ??
             throw new JsonException("Invalid response from Vault");
         }
     }

--- a/Api/Service/Broker/VaultHttpClientBrokerService/VaultHttpClientBrokerService.cs
+++ b/Api/Service/Broker/VaultHttpClientBrokerService/VaultHttpClientBrokerService.cs
@@ -24,6 +24,7 @@ namespace Api.Service.Broker.VaultHttpClientBrokerService
             string requestId = new UUID().ToFormattedString();
 
             httpRequestMessage.Headers.Add("X-Request-Id", requestId);
+            httpRequestMessage.Headers.Add("X-Vault-Token", appSettings.VaultHttpClient.Token);
 
             Stopwatch stopwatch = Stopwatch.StartNew();
 

--- a/Api/Service/Foundation/VaultFoundationService.cs
+++ b/Api/Service/Foundation/VaultFoundationService.cs
@@ -19,6 +19,7 @@ namespace Api.Service.Foundation
             DateTimeOffset expiryDate = DateTimeOffset.UtcNow.AddSeconds(postVaultAuthResponseDto.LeaseDuration);
 
             appSettings.VaultHttpClient.ExpireAt = expiryDate;
+            appSettings.VaultHttpClient.Token = postVaultAuthResponseDto.ClientToken;
 
             Log.Information($"Vault token retrieved. (Expired at {appSettings.VaultHttpClient.ExpireAt})");
 
@@ -39,11 +40,11 @@ namespace Api.Service.Foundation
 
         public async ValueTask<AppSettings> RetrieveVaultPostgresCredentialAsync(string databaseEngineName, string databaseEngineRole, CancellationToken cancellationToken = default)
         {
-            PostVaultDatabaseCredentialResponseDto postVaultDatabaseCredentialDto = await iVaultHttpClientBrokerService.PostPostgresCredentialAsync(databaseEngineName, databaseEngineRole, cancellationToken);
+            VaultResponseWrapperDto<PostVaultDatabaseCredentialResponseDto> vaultResponseWrapperDto = await iVaultHttpClientBrokerService.PostPostgresCredentialAsync(databaseEngineName, databaseEngineRole, cancellationToken);
 
-            appSettings.PostgresSettings.Username = postVaultDatabaseCredentialDto.Username;
-            appSettings.PostgresSettings.Password = postVaultDatabaseCredentialDto.Password;
-            appSettings.PostgresSettings.ExpireAt = DateTimeOffset.UtcNow.AddSeconds(postVaultDatabaseCredentialDto.LeaseDuration);
+            appSettings.PostgresSettings.Username = vaultResponseWrapperDto.Data.Username;
+            appSettings.PostgresSettings.Password = vaultResponseWrapperDto.Data.Password;
+            appSettings.PostgresSettings.ExpireAt = DateTimeOffset.UtcNow.AddSeconds(vaultResponseWrapperDto.LeaseDuration);
 
             Log.Information("Vault postgres temporary credentials retrieved");
 

--- a/Configuration/Postgres/Model/PostgresSettings.cs
+++ b/Configuration/Postgres/Model/PostgresSettings.cs
@@ -20,7 +20,7 @@ namespace Postgres.Model
         public string VaultDatabaseEngineRole { get; set; } = string.Empty;
 
         [JsonIgnore]
-        public DateTimeOffset? ExpireAt { get; set; } = null;
+        public DateTimeOffset ExpireAt { get; set; } = DateTimeOffset.UtcNow;
 
         [JsonIgnore]
         public string Username { get; set; } = string.Empty;


### PR DESCRIPTION
<!--- Provide a concise summary in the PR title -->

## Description
<!-- Describe your changes clearly and concisely -->
This change refactors the Vault integration and background scheduling system by centralizing authentication state, improving response modeling, and migrating from a background-service-based refresh approach to a Quartz-driven self-rescheduling job architecture. Vault token handling is moved into AppSettings and injected per request to remove HttpClient side effects, while credential responses are standardized using a unified wrapper model. The previous single background service is removed and replaced with two dedicated hosted services for AppSettings and Postgres credential refresh. Both refresh flows now rely on Quartz jobs that reschedule themselves based on 80% of the remaining expiry window, ensuring proactive rotation before expiration without external orchestration. Additional model and configuration adjustments improve safety, clarity, and consistency across Vault-related components.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
The previous implementation mixed authentication state management, HTTP client mutation, and scheduling logic across multiple layers, making Vault behavior harder to reason about and maintain. This refactor aims to isolate responsibilities: Vault authentication state is now centrally managed, HTTP requests are stateless and explicit, and scheduling logic is fully owned by Quartz jobs. Moving to self-rescheduling jobs reduces startup complexity and eliminates duplicated scheduling paths while ensuring credential rotation happens reliably and predictably before expiry.

## Related Issue
Closes #21 

## How Has This Been Tested?
<!-- Describe how you validated your changes -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps below)

**Test Details:**
<!-- e.g. API endpoint tested, payload used, expected vs actual -->
Setup scheduler job to run a couple minute after Postgres credential is acquired and check if the job run without error and able to reschedule for next iteration.

## API Changes (if applicable)
<!-- Important for frontend + consumers -->
- [x] No API changes
- [ ] New endpoint(s)
- [ ] Modified request/response
- [ ] Breaking change

**Details:**
<!-- Include route, request DTO, response DTO, status codes -->

## Database Changes (if applicable)
- [x] No DB changes
- [ ] Migration added
- [ ] Schema updated
- [ ] Seed data updated

**Migration Notes:**
<!-- e.g. dotnet ef migrations add ... -->

## Configuration Changes (if applicable)
- [ ] No config changes
- [x] appsettings updated
- [ ] New environment variables required

**Details:**
<!-- Describe required keys, example values -->
Added token key

## Performance / Impact
<!-- Optional but valuable -->
- Any performance considerations?
- Any potential bottlenecks or risks?

## Logs / Observability
- [x] Logging added/updated
- [ ] Metrics/Tracing considered

## Types of Changes
- [ ] Bug fix (non-breaking)
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary dependencies added
- [x] Proper error handling implemented
- [x] Logging added where necessary
- [ ] API responses follow `ResponseWrapper` format
- [ ] Sensitive data is not exposed
- [ ] Migration tested (if applicable)
- [ ] Documentation updated (if needed)

## Screenshots / Examples (if applicable)
<!-- Request/response samples, Swagger screenshots, etc. -->

## Post-Deployment Notes (optional)
<!-- Anything ops/dev should know after merge -->