### PR TITLE
Isolate Quartz scheduler persistence with Vault-managed dedicated credentials and schema separation

### DIFF
--- a/Api/Model/Common/AppSettings.cs
+++ b/Api/Model/Common/AppSettings.cs
@@ -1,6 +1,7 @@
 using Common.Interface;
 using Cors.Model;
 using Postgres.Model;
+using QuartzScheduler.Model;
 
 namespace Api.Model.Common
 {
@@ -9,6 +10,9 @@ namespace Api.Model.Common
         public VaultHttpClient VaultHttpClient { get; set; } = new();
         public CorsPolicy[] CorsPolicyList { get; set; } = [];
         public PostgresSettings PostgresSettings { get; set; } = new();
+        public QuartzSettings QuartzSettings { get; set; } = new();
+
+        public string GenerateQuartzConnectionString() => $"Host={PostgresSettings.Host};Port={PostgresSettings.Port};Database={PostgresSettings.DatabaseName};Username={QuartzSettings.Username};Password={QuartzSettings.Password};Pooling=false;";
     }
     public class VaultHttpClient
     {

--- a/Api/Model/Dto/Request/PostRegisterUserRequestDto.cs
+++ b/Api/Model/Dto/Request/PostRegisterUserRequestDto.cs
@@ -7,6 +7,7 @@ namespace Api.Model.Dto.Request
     {
         [GenericRequired]
         [EmailAddress]
+        [GenericStringLength(254)]
         public string Email { get; set; } = string.Empty;
 
         [GenericRequired]

--- a/Api/Model/Dto/Response/GetVaultRootSecretResponseDto.cs
+++ b/Api/Model/Dto/Response/GetVaultRootSecretResponseDto.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 using Cors.Model;
 using Postgres.Model;
+using QuartzScheduler.Model;
 
 namespace Api.Model.Dto.Response
 {
@@ -16,5 +17,8 @@ namespace Api.Model.Dto.Response
 
         [JsonPropertyName("postgres_settings")]
         public required PostgresSettings PostgresSettings { get; set; }
+
+        [JsonPropertyName("quartz_settings")]
+        public required QuartzSettings QuartzSettings { get; set; }
     }
 }

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -53,7 +53,7 @@ builder.Services.SetupSwagger();
 
 builder.Services.SetupPostgresDatabaseContext<PersonaContext>(appsettings.PostgresSettings);
 
-builder.Services.SetupQuartzScheduler(appsettings.PostgresSettings.GenerateConnectionString());
+builder.Services.SetupQuartzScheduler(appsettings.GenerateQuartzConnectionString());
 
 builder.Services.AddResponseCaching();
 
@@ -66,7 +66,7 @@ WebApplication app = builder.Build();
 
 await app.Services.CheckAndApplyMigrationsAsync<PersonaContext>();
 
-await app.Services.EnsureQuartzSchemaAsync<PersonaContext>(appsettings.PostgresSettings.GenerateConnectionString());
+await app.Services.EnsureQuartzSchemaAsync<PersonaContext>(appsettings.GenerateQuartzConnectionString());
 
 app.UseHttpsRedirection();
 

--- a/Api/Service/Foundation/VaultFoundationService.cs
+++ b/Api/Service/Foundation/VaultFoundationService.cs
@@ -32,6 +32,7 @@ namespace Api.Service.Foundation
 
             appSettings.CorsPolicyList = getVaultRootSecretResponseDto.CorsPolicyList;
             appSettings.PostgresSettings = getVaultRootSecretResponseDto.PostgresSettings;
+            appSettings.QuartzSettings = getVaultRootSecretResponseDto.QuartzSettings;
 
             Log.Information("Vault secret settings retrieved");
 

--- a/Configuration/Postgres/PostgresConfiguration.cs
+++ b/Configuration/Postgres/PostgresConfiguration.cs
@@ -77,39 +77,29 @@ public static class PostgresConfiguration
         using IServiceScope scope = services.CreateScope();
         ILogger logger = scope.ServiceProvider.GetRequiredService<ILogger<T>>();
 
-        await using var conn = new NpgsqlConnection(connectionString);
+        await using NpgsqlConnection conn = new(connectionString);
         await conn.OpenAsync();
 
-        await using var checkCmd = new NpgsqlCommand(@"
+        await using NpgsqlCommand checkCmd = new(@"
             SELECT EXISTS (
                 SELECT 1
                 FROM information_schema.tables
-                WHERE table_schema = 'public'
+                WHERE table_schema = 'quartz'
                 AND table_name = 'qrtz_job_details'
             );
         ", conn);
 
-        var exists = (bool)(await checkCmd.ExecuteScalarAsync() ?? false);
-
-        if (exists)
+        if ((bool)(await checkCmd.ExecuteScalarAsync() ?? false))
             return;
 
-        var assembly = typeof(PostgresConfiguration).Assembly;
+        await using Stream stream = typeof(PostgresConfiguration).Assembly
+        .GetManifestResourceStream("Postgres.Script.quartz_schema.sql")
+        ?? throw new InvalidOperationException("Quartz schema script not found.");
 
-        var names = assembly.GetManifestResourceNames();
-        foreach (var n in names)
-        {
-            Console.WriteLine(n);
-        }
+        using StreamReader reader = new(stream);
+        string sql = await reader.ReadToEndAsync();
 
-        await using var stream = assembly.GetManifestResourceStream(
-            "Postgres.Script.quartz_schema.sql")
-            ?? throw new InvalidOperationException("Quartz schema script not found.");
-
-        using var reader = new StreamReader(stream);
-        var sql = await reader.ReadToEndAsync();
-
-        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using NpgsqlCommand cmd = new(sql, conn);
         await cmd.ExecuteNonQueryAsync();
 
         logger.LogInformation($"Quartz schema initialized");

--- a/Configuration/QuartzScheduler/Model/QuartzSettings.cs
+++ b/Configuration/QuartzScheduler/Model/QuartzSettings.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace QuartzScheduler.Model
+{
+    public sealed class QuartzSettings
+    {
+        [JsonPropertyName("username")]
+        public string Username { get; set; } = string.Empty;
+
+        [JsonPropertyName("password")]
+        public string Password { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
<!--- Provide a concise summary in the PR title -->

## Description
<!-- Describe your changes clearly and concisely -->
This change introduces a dedicated configuration and credential flow for Quartz scheduler persistence. Quartz now uses a separate database account and connection string sourced from Vault root secret settings instead of sharing dynamic Postgres credentials used by the application runtime.

A new QuartzSettings model is introduced and integrated into the Vault root secret retrieval process. AppSettings now centralizes both application and Quartz-specific database credentials. Quartz initialization and scheduler setup are updated to consume this dedicated connection string, ensuring isolation from application-level credential rotation.

Additionally, schema initialization logic is refined to target a dedicated quartz schema and improve initialization safety and clarity.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Quartz was previously using the same dynamically rotated Postgres credentials as the main application. This caused instability when Vault rotated credentials, leading to authentication failures and scheduler disruption.

Since Quartz relies on persistent database connections for job scheduling and locking, it requires a stable set of credentials that are not affected by frequent rotation of application credentials.

This change:

- Prevents Quartz failures during Vault credential rotation
- Separates concerns between application runtime DB access and scheduler persistence
- Improves operational stability of background jobs
- Aligns Quartz with a dedicated, long-lived database role model for persistence storage

## Related Issue
Closes #28 

## How Has This Been Tested?
<!-- Describe how you validated your changes -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (describe steps below)

**Test Details:**
<!-- e.g. API endpoint tested, payload used, expected vs actual -->

1. Start the application
2. Application retrieves temporary PostgreSQL credentials from Vault
3. Quartz scheduler starts successfully using the temporary credentials
4. Wait until the Postgres credential refresh job rotates the Vault-generated credentials
5. Observe Quartz logs after the previous credentials expire

## API Changes (if applicable)
<!-- Important for frontend + consumers -->
- [x] No API changes
- [ ] New endpoint(s)
- [ ] Modified request/response
- [ ] Breaking change

**Details:**
<!-- Include route, request DTO, response DTO, status codes -->

## Database Changes (if applicable)
- [x] No DB changes
- [ ] Migration added
- [ ] Schema updated
- [ ] Seed data updated

**Migration Notes:**
<!-- e.g. dotnet ef migrations add ... -->

## Configuration Changes (if applicable)
- [ ] No config changes
- [ ] appsettings updated
- [x] New environment variables required

**Details:**
<!-- Describe required keys, example values -->
added quartz settings section with username and password for static role to access quartz schema

## Performance / Impact
<!-- Optional but valuable -->
- Any performance considerations?
- Any potential bottlenecks or risks?

## Logs / Observability
- [x] Logging added/updated
- [ ] Metrics/Tracing considered

## Types of Changes
- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Chore

## Checklist
- [x] Code follows project conventions
- [x] No unnecessary dependencies added
- [x] Proper error handling implemented
- [x] Logging added where necessary
- [ ] API responses follow `ResponseWrapper` format
- [ ] Sensitive data is not exposed
- [ ] Migration tested (if applicable)
- [ ] Documentation updated (if needed)

## Screenshots / Examples (if applicable)
<!-- Request/response samples, Swagger screenshots, etc. -->

## Post-Deployment Notes (optional)
<!-- Anything ops/dev should know after merge -->